### PR TITLE
Add CoffeeScript (.coffee files) support for customTasksDir

### DIFF
--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -52,8 +52,11 @@ module.exports = function (grunt) {
     },
     custom3: {
       say: {}
+    },
+    custom4: {
+      say: {}
     }
   });
 
-  grunt.registerTask('default', ['clean', 'custom1', 'assemble', 'wget', 'custom2', 'newer:jshint', 'custom3']);
+  grunt.registerTask('default', ['clean', 'custom1', 'assemble', 'wget', 'custom2', 'newer:jshint', 'custom3', 'custom4']);
 };

--- a/example/custom/custom4.coffee
+++ b/example/custom/custom4.coffee
@@ -1,0 +1,3 @@
+module.exports = (grunt) ->
+  grunt.registerMultiTask 'custom4', 'custom task 4', ->
+    grunt.log.ok('custom4!')

--- a/lib/jit-grunt.js
+++ b/lib/jit-grunt.js
@@ -33,6 +33,10 @@ jit.findPlugin = function (taskName) {
     if (fs.existsSync(taskPath)) {
       return this.createLoader(taskName, taskPath, true);
     }
+    taskPath = path.join(jit.customTasksDir, taskName + '.coffee');
+    if (fs.existsSync(taskPath)) {
+      return this.createLoader(taskName, taskPath, true);
+    }
   }
 
   var dashedName = taskName.replace(/([A-Z])/g, '-$1').replace(/_+/g, '-').toLowerCase();

--- a/test/findPluginSpec.js
+++ b/test/findPluginSpec.js
@@ -94,6 +94,21 @@ describe('Plugin find', function () {
     assert(!stub.calledWith(path.resolve('node_modules/foo/tasks')));
   });
 
+  it('Custom task: CoffeeScript', function () {
+    jit.customTasksDir = path.resolve('custom');
+
+    stub.withArgs(path.resolve('custom/foo.js')).returns(false);
+    stub.withArgs(path.resolve('custom/foo.coffee')).returns(true);
+
+    assert(jit.findPlugin('foo'));
+
+    assert(stub.calledWith(path.resolve('custom/foo.js')));
+    assert(stub.calledWith(path.resolve('custom/foo.coffee')));
+    assert(!stub.calledWith(path.resolve('node_modules/grunt-contrib-foo/tasks')));
+    assert(!stub.calledWith(path.resolve('node_modules/grunt-foo/tasks')));
+    assert(!stub.calledWith(path.resolve('node_modules/foo/tasks')));
+  });
+
   it('not Found', function () {
     stub.withArgs(path.resolve('node_modules/grunt-contrib-foo/tasks')).returns(false);
     stub.withArgs(path.resolve('node_modules/grunt-foo/tasks')).returns(false);


### PR DESCRIPTION
This adds support for auto-loading `.coffee` files from the `customTasksDir` directory.
