### PR TITLE
traverse upward when loading node modules

### DIFF
--- a/lib/jit-grunt.js
+++ b/lib/jit-grunt.js
@@ -1,6 +1,7 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
+var findup = require('findup-sync');
 
 var PREFIXES = ['', 'grunt-', 'grunt-contrib-'];
 var EXTENSIONS = ['.coffee', '.js'];
@@ -8,6 +9,31 @@ var EXTENSIONS = ['.coffee', '.js'];
 var jit = {
   pluginsRoot: path.resolve('node_modules'),
   mappings: {}
+};
+
+jit.findPluginPath = function(pluginName) {
+  var taskPath;
+  taskPath = path.join(jit.pluginsRoot, pluginName, 'tasks');
+  if (fs.existsSync(taskPath)) {
+    return taskPath;
+  }
+
+  // If our pluginsRoot is a node_modules folder, traverse the directory tree
+  // upward, following npm's conventions.
+  if (jit.pluginsRoot.match(/node_modules/)) {
+    var npmPath = findup(path.join('node_modules', pluginName), {
+      cwd: jit.pluginsRoot,
+      nocase: true
+    });
+    if (npmPath) {
+      taskPath = path.join(npmPath, 'tasks');
+      if (fs.existsSync(taskPath)) {
+        return taskPath;
+      }
+    }
+  }
+
+  return false;
 };
 
 jit.findPlugin = function (taskName) {
@@ -20,8 +46,8 @@ jit.findPlugin = function (taskName) {
         return jit.loadPlugin(taskName, taskPath, true);
       }
     } else {
-      taskPath = path.join(jit.pluginsRoot, pluginName, 'tasks');
-      if (fs.existsSync(taskPath)) {
+      taskPath = jit.findPluginPath(pluginName);
+      if (taskPath) {
         return jit.loadPlugin(pluginName, taskPath);
       }
     }
@@ -40,8 +66,8 @@ jit.findPlugin = function (taskName) {
 
   for (var p = PREFIXES.length; p--;) {
     pluginName = PREFIXES[p] + dashedName;
-    taskPath = path.join(jit.pluginsRoot, pluginName, 'tasks');
-    if (fs.existsSync(taskPath)) {
+    taskPath = jit.findPluginPath(pluginName);
+    if (taskPath) {
       return jit.loadPlugin(pluginName, taskPath);
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "espower-loader": "~0.9.0",
+    "findup-sync": "~0.1.3",
     "grunt": "~0.4.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-jshint": "~0.10.0",


### PR DESCRIPTION
Resolves #20.  

Brings jit-grunt's behavior (somewhat) into line with the way that `grunt.task.loadGruntTasks()` and node's `require()` functions work.  I don't delegate directly to either of those methods, because they would rob us of the ability to manually set a "root" folder.

Feedback is always appreciated.  
