### PR TITLE
Allow user to specify working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,19 @@ require('jit-grunt')(grunt, {
 
 ### Options
 
+#### cwd
+
+Type: `Strong`
+Default: `process.cwd()`
+
+All plugins and tasks are resolved relative to this path.
+
 #### pluginsRoot
 
 Type: `String`  
 Default: `'node_modules'`
 
-Root directory of grunt plugins.
+Root directory of grunt plugins, relative to the working directory.
 
 ```js
 require('jit-grunt')(grunt)({
@@ -122,7 +129,7 @@ require('jit-grunt')(grunt)({
 Type: `String`  
 Default: `null`
 
-JIT Loading for custom tasks dir (replacement of [grunt.loadTasks]).
+JIT Loading for custom tasks dir (replacement of [grunt.loadTasks]), relative to the working directory..
 
 ```js
 require('jit-grunt')(grunt)({

--- a/jit-grunt.js
+++ b/jit-grunt.js
@@ -18,5 +18,10 @@ module.exports = function (grunt, mappings) {
     if (options.pluginsRoot) {
       jit.pluginsRoot = options.pluginsRoot;
     }
+
+    if (options.cwd) {
+      jit.cwd = options.cwd;
+    }
+
   };
 };

--- a/lib/jit-grunt.js
+++ b/lib/jit-grunt.js
@@ -7,7 +7,8 @@ var EXTENSIONS = ['.coffee', '.js'];
 
 var jit = {
   pluginsRoot: 'node_modules',
-  mappings: {}
+  mappings: {},
+  cwd: process.cwd()
 };
 
 
@@ -28,13 +29,13 @@ jit.findPlugin = function (taskName) {
   if (this.mappings.hasOwnProperty(taskName)) {
     pluginName = this.mappings[taskName];
     if (pluginName.indexOf('/') >= 0 && pluginName.indexOf('@') !== 0) {
-      taskPath = path.resolve(pluginName);
+      taskPath = path.resolve(this.cwd, pluginName);
       if (fs.existsSync(taskPath)) {
         return jit.loadPlugin(taskName, taskPath, true);
       }
     } else {
       var dir = path.join(jit.pluginsRoot, pluginName, 'tasks');
-      taskPath = jit.findUp(path.resolve(), function (cwd) {
+      taskPath = jit.findUp(this.cwd, function (cwd) {
         var findPath = path.join(cwd, dir);
         return fs.existsSync(findPath) ? findPath : null;
       });
@@ -56,7 +57,7 @@ jit.findPlugin = function (taskName) {
 
   // Auto Mappings
   var dashedName = taskName.replace(/([A-Z])/g, '-$1').replace(/_+/g, '-').toLowerCase();
-  taskPath = jit.findUp(path.resolve(), function (cwd) {
+  taskPath = jit.findUp(this.cwd, function (cwd) {
     for (var p = PREFIXES.length; p--;) {
       pluginName = PREFIXES[p] + dashedName;
       var findPath = path.join(cwd, jit.pluginsRoot, pluginName, 'tasks');


### PR DESCRIPTION
This allows for more flexible usage of the `pluginsRoot` option, particularly when we want the various findUp semantics to work properly if we specify a `pluginsRoot` that is completely outside of the process's working directory.

This is a proposed (partial-ish) solution to #40.